### PR TITLE
[LATEST] PLATFORM: Upgrade toolchain to Java 25

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,9 @@ jobs:
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: |
+            21
+            25
       - name: Check
         run: ./gradlew check
       - name: Publish to Maven Central

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,10 +73,16 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(25)
     }
     withJavadocJar()
     withSourcesJar()
+}
+
+tasks.compileJava {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 tasks.withType<Jar>().configureEach {


### PR DESCRIPTION
Upgrade the build toolchain to Java 25 and set the compile target to Java 21 via a compilerFor override (was 11).

Part of INT-8.